### PR TITLE
Set default region to us east

### DIFF
--- a/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -18,7 +18,7 @@ MonoBehaviour:
     AppIdVoice: 
     AppVersion: 
     UseNameServer: 1
-    FixedRegion: 
+    FixedRegion: us
     Server: 
     Port: 0
     ProxyServer: 
@@ -26,7 +26,7 @@ MonoBehaviour:
     EnableProtocolFallback: 1
     AuthMode: 0
     EnableLobbyStatistics: 0
-    NetworkLogging: 1
+    NetworkLogging: 5
   DevRegion: 
   PunLogging: 2
   EnableSupportLogger: 0
@@ -36,5 +36,5 @@ MonoBehaviour:
   - ClickRpc
   - DestroyRpc
   DisableAutoOpenWizard: 1
-  ShowSettings: 0
+  ShowSettings: 1
   DevRegionSetOnce: 0

--- a/Assets/Resources/SquareSizePlayer.prefab
+++ b/Assets/Resources/SquareSizePlayer.prefab
@@ -16,7 +16,7 @@ GameObject:
   - component: {fileID: 3183360715286171950}
   - component: {fileID: 3673321227508684739}
   m_Layer: 0
-  m_Name: Player
+  m_Name: SquareSizePlayer
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0

--- a/Assets/Scenes/Menus/MainMenu.cs
+++ b/Assets/Scenes/Menus/MainMenu.cs
@@ -33,10 +33,15 @@ public class MainMenu : MonoBehaviourPunCallbacks
     // Networking -- Currently Finds One other player and starts game immediately
     // TODO: Create a lobby/waiting room where players can see others and wait to start (possibly with a host or readyup system)
 
-    private void Awake() => PhotonNetwork.AutomaticallySyncScene = true;
+    private void Awake()
+    {
+        PhotonNetwork.PhotonServerSettings.AppSettings.FixedRegion = "us";
+        PhotonNetwork.AutomaticallySyncScene = true;
+    }
 
     public void FindOpponent()
     {
+
         isConnecting = true;
 
         findOpponentPanel.SetActive(false);
@@ -115,7 +120,7 @@ public class MainMenu : MonoBehaviourPunCallbacks
 
     public void PlayGame()
     {
-
+        PhotonNetwork.PhotonServerSettings.AppSettings.FixedRegion = "us";
         PhotonNetwork.NickName = nickname;
 
         /*SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex + 1);*/


### PR DESCRIPTION
**Issue**: Players could not connect to each other despite both connecting to photon properly. They would connect to their own rooms but not with each other. 

**Found Reason**: https://doc.photonengine.com/en-us/pun/current/connection-and-authentication/regions#best_region_considerations
Photon's region selector is a bit broken, even when clients are on the same network the region selector will select different regions. Additionally, players cannot connect to players in different regions.

**Solution**: Fixed Connection issues in by setting the default region to be "us" which is the us east region in photon

